### PR TITLE
Make OTAPI more .NET core-compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ Steamworks.NET.dll
 
 *.lock.json
 OTAPI.Core.Tests/lib/net451/OTAPI.Sockets.dll
+/OTAPI.Server.sln.DotSettings.user

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ install:
 script:
   - wget -O server.zip http://terraria.org/system/dedicated_servers/archives/000/000/032/original/terraria-server-1353.zip?1515098333
   - unzip server.zip -d tmp_server_zip
-  - cp "tmp_server_zip/Windows/TerrariaServer.exe" wrap/TerrariaServer/TerrariaServer.exe
+  - cp "tmp_server_zip/1353/Windows/TerrariaServer.exe" wrap/TerrariaServer/TerrariaServer.exe
   - xbuild /p:Configuration=Debug OTAPI.Server.sln

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
   - sudo apt-get install unzip
   - nuget restore OTAPI.Server.sln
 script:
-  - wget -O server.zip http://terraria.org/system/dedicated_servers/archives/000/000/030/original/terraria-server-1352.zip?1492809085
+  - wget -O server.zip http://terraria.org/system/dedicated_servers/archives/000/000/032/original/terraria-server-1353.zip?1515098333
   - unzip server.zip -d tmp_server_zip
   - cp "tmp_server_zip/Windows/TerrariaServer.exe" wrap/TerrariaServer/TerrariaServer.exe
   - xbuild /p:Configuration=Debug OTAPI.Server.sln

--- a/OTAPI.Modifications/OTAPI.Modifications.Mono/Callbacks/IO.cs
+++ b/OTAPI.Modifications/OTAPI.Modifications.Mono/Callbacks/IO.cs
@@ -2,26 +2,10 @@
 {
 	internal static partial class IO
 	{
-		private static bool IsMono()
-		{
-			return System.Type.GetType("Mono.Runtime") != null;
-		}
-
 		internal static bool DeleteFile(string path)
 		{
-			bool deleted = false;
-
-			if (IsMono())
-			{
-				System.IO.File.Delete(path);
-				deleted = true;
-			}
-			else
-			{
-				deleted = global::Terraria.Utilities.FileOperationAPIWrapper.MoveToRecycleBin(path);
-			}
-
-			return deleted;
+			System.IO.File.Delete(path);
+			return true;
 		}
 	}
 }

--- a/OTAPI.Modifications/OTAPI.Modifications.Mono/Modifications/HandlePlatformIO.cs
+++ b/OTAPI.Modifications/OTAPI.Modifications.Mono/Modifications/HandlePlatformIO.cs
@@ -11,6 +11,9 @@ namespace OTAPI.Modifications.Mono.Modifications
 	/// Since we use the Windows TerrariaServer.exe we need to handle windows specific code
 	/// In this case we need to replace all calls to 'FileOperationAPIWrapper.MoveToRecycleBin'
 	/// and redirect them to our own callback that will handle mono+.net
+	///
+	/// UPDATE: This PInvoke is apparently quite broken on .net core, so I have decided to remove it for all platforms.
+	/// - Kevin
 	/// </summary>
 	public class HandlePlatformIO : ModificationBase
 	{

--- a/OTAPI.Modifications/OTAPI.Modifications.Net.NetworkText/Modifications/SendChatMessageToClientModification.cs
+++ b/OTAPI.Modifications/OTAPI.Modifications.Net.NetworkText/Modifications/SendChatMessageToClientModification.cs
@@ -18,12 +18,12 @@ namespace OTAPI.Modifications.NetworkText.Modifications
 		{
 			Color tmpColor = new Color();
 			int tmpInt = 0;
-			var broadcastChatMessage = Method<Terraria.NetMessage>("SendChatMessageToClient", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public);
-			var broadcastChatMessageBeforeCallback = Method(() => Callbacks.Terraria.NetMessage.BeforeBroadcastChatMessage(null, ref tmpColor, ref tmpInt));
-			var broadcastChatMessageAfterCallback = Method(() => Callbacks.Terraria.NetMessage.AfterBroadcastChatMessage(null, ref tmpColor, ref tmpInt));
+			var sendChatMessage = Method<Terraria.NetMessage>("SendChatMessageToClient", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public);
+			var sendChatMessageBeforeCallback = Method(() => Callbacks.Terraria.NetMessage.BeforeSendChatMessageToClient(null, ref tmpColor, ref tmpInt));
+			var sendChatMessageAfterCallback = Method(() => Callbacks.Terraria.NetMessage.AfterSendChatMessageToClient(null, ref tmpColor, ref tmpInt));
 
-			broadcastChatMessage.Wrap(broadcastChatMessageBeforeCallback, 
-				broadcastChatMessageAfterCallback,
+			sendChatMessage.Wrap(sendChatMessageBeforeCallback, 
+				sendChatMessageAfterCallback,
 				beginIsCancellable: true,
 				noEndHandling: true,
 				allowCallbackInstance: false);

--- a/OTAPI.Modifications/OTAPI.Modifications.NetCore/Modifications/RemoveSystemWindowsForms.cs
+++ b/OTAPI.Modifications/OTAPI.Modifications.NetCore/Modifications/RemoveSystemWindowsForms.cs
@@ -1,0 +1,30 @@
+﻿using System.Linq;
+using OTAPI.Patcher.Engine.Modification;
+
+namespace OTAPI.Patcher.Engine.Modifications.Patches
+{
+	/// <summary>
+	/// Replaces all System.Windows.Forms references to use OTAPI.Modifications.NetCore.dll
+	/// </summary>
+	public class RemoveSystemWindowsForms : ModificationBase
+	{
+		public override System.Collections.Generic.IEnumerable<string> AssemblyTargets => new[]
+		{
+			"TerrariaServer, Version=1.3.5.3, Culture=neutral, PublicKeyToken=null",
+			"ReLogic, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"
+		};
+		public override string Description => "Removing System.Windows.Forms references...";
+
+		public override void Run()
+		{
+			foreach (var reference in SourceDefinition.MainModule.AssemblyReferences
+				.Where(x => x.Name.StartsWith("System.Windows.Forms")))
+			{
+				reference.Name = "OTAPI.Modifications.NetCore";
+				reference.PublicKey = ModificationDefinition.Name.PublicKey;
+				reference.PublicKeyToken = ModificationDefinition.Name.PublicKeyToken;
+				reference.Version = ModificationDefinition.Name.Version;
+			}
+		}
+	}
+}

--- a/OTAPI.Modifications/OTAPI.Modifications.NetCore/Modifications/RemoveWindowsBase.cs
+++ b/OTAPI.Modifications/OTAPI.Modifications.NetCore/Modifications/RemoveWindowsBase.cs
@@ -1,0 +1,29 @@
+﻿using System.Linq;
+using OTAPI.Patcher.Engine.Modification;
+
+namespace OTAPI.Patcher.Engine.Modifications.Patches
+{
+	/// <summary>
+	/// Replaces all WindowsBase references to use OTAPI.Modifications.NetCore.dll
+	/// </summary>
+	public class RemoveWindowsBase : ModificationBase
+	{
+		public override System.Collections.Generic.IEnumerable<string> AssemblyTargets => new[]
+		{
+			"TerrariaServer, Version=1.3.5.3, Culture=neutral, PublicKeyToken=null"
+		};
+		public override string Description => "Removing WindowsBase references...";
+
+		public override void Run()
+		{
+			foreach (var reference in SourceDefinition.MainModule.AssemblyReferences
+				.Where(x => x.Name.StartsWith("WindowsBase")))
+			{
+				reference.Name = "OTAPI.Modifications.NetCore";
+				reference.PublicKey = ModificationDefinition.Name.PublicKey;
+				reference.PublicKeyToken = ModificationDefinition.Name.PublicKeyToken;
+				reference.Version = ModificationDefinition.Name.Version;
+			}
+		}
+	}
+}

--- a/OTAPI.Modifications/OTAPI.Modifications.NetCore/OTAPI.Modifications.NetCore.csproj
+++ b/OTAPI.Modifications/OTAPI.Modifications.NetCore/OTAPI.Modifications.NetCore.csproj
@@ -1,0 +1,85 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{C805D018-48D3-4B93-BED7-99C7ECD8837C}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>OTAPI.Modifications.NetCore</RootNamespace>
+    <AssemblyName>OTAPI.Modifications.NetCore</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Debug\OTAPI.Modifications.NetCore.xml</DocumentationFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <DocumentationFile>bin\Release\OTAPI.Modifications.NetCore.xml</DocumentationFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756">
+      <HintPath>..\..\packages\Mono.Cecil.0.9.6.4\lib\net45\Mono.Cecil.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Mdb, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756">
+      <HintPath>..\..\packages\Mono.Cecil.0.9.6.4\lib\net45\Mono.Cecil.Mdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Pdb, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756">
+      <HintPath>..\..\packages\Mono.Cecil.0.9.6.4\lib\net45\Mono.Cecil.Pdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Rocks, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756">
+      <HintPath>..\..\packages\Mono.Cecil.0.9.6.4\lib\net45\Mono.Cecil.Rocks.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="TerrariaServer">
+      <HintPath>..\..\wrap\TerrariaServer\TerrariaServer.exe</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Modifications\RemoveWindowsBase.cs" />
+    <Compile Include="Modifications\RemoveSystemWindowsForms.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="System.IO\FileFormatException.cs" />
+    <Compile Include="System.Windows.Forms\Application.cs" />
+    <Compile Include="System.Windows.Forms\Control.cs" />
+    <Compile Include="System.Windows.Forms\Form.cs" />
+    <Compile Include="System.Windows.Forms\FormWindowState.cs" />
+    <Compile Include="System.Windows.Forms\IMessageFilter.cs" />
+    <Compile Include="System.Windows.Forms\Message.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\OTAPI.Patcher.Engine\OTAPI.Patcher.Engine.csproj">
+      <Project>{A1F792B2-5D80-4DE4-B5DB-7A05DBEABD60}</Project>
+      <Name>OTAPI.Patcher.Engine</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\OTAPI.Modifications.Core\OTAPI.Modifications.Core.csproj">
+      <Project>{D9439E01-19C1-4E89-9B33-2C19C804DDCF}</Project>
+      <Name>OTAPI.Modifications.Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/OTAPI.Modifications/OTAPI.Modifications.NetCore/Properties/AssemblyInfo.cs
+++ b/OTAPI.Modifications/OTAPI.Modifications.NetCore/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("OTAPI.Modifications.NetCore")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("OTAPI.Modifications.NetCore")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("c805d018-48d3-4b93-bed7-99c7ecd8837c")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/OTAPI.Modifications/OTAPI.Modifications.NetCore/System.IO/FileFormatException.cs
+++ b/OTAPI.Modifications/OTAPI.Modifications.NetCore/System.IO/FileFormatException.cs
@@ -1,0 +1,10 @@
+﻿namespace System.IO
+{
+	[Serializable]
+	public class FileFormatException : FormatException
+	{
+		public FileFormatException() : base() { }
+
+		public FileFormatException(string message) : base(message) { }
+	}
+}

--- a/OTAPI.Modifications/OTAPI.Modifications.NetCore/System.Windows.Forms/Application.cs
+++ b/OTAPI.Modifications/OTAPI.Modifications.NetCore/System.Windows.Forms/Application.cs
@@ -1,0 +1,10 @@
+﻿namespace System.Windows.Forms
+{
+	public sealed class Application
+	{
+		public static event EventHandler ApplicationExit;
+
+		public static void AddMessageFilter(IMessageFilter value) => throw new NotImplementedException();
+		public static void RemoveMessageFilter(IMessageFilter value) => throw new NotImplementedException();
+	}
+}

--- a/OTAPI.Modifications/OTAPI.Modifications.NetCore/System.Windows.Forms/Control.cs
+++ b/OTAPI.Modifications/OTAPI.Modifications.NetCore/System.Windows.Forms/Control.cs
@@ -1,0 +1,9 @@
+﻿namespace System.Windows.Forms
+{
+	public class Control
+	{
+		public Drawing.Point Location { get; set; }
+
+		public static Control FromHandle(IntPtr handle) => null;
+	}
+}

--- a/OTAPI.Modifications/OTAPI.Modifications.NetCore/System.Windows.Forms/Form.cs
+++ b/OTAPI.Modifications/OTAPI.Modifications.NetCore/System.Windows.Forms/Form.cs
@@ -1,0 +1,9 @@
+﻿namespace System.Windows.Forms
+{
+	public class Form : Control
+	{
+		public FormWindowState WindowState { get; set; }
+
+		public static Form ActiveForm => null;
+	}
+}

--- a/OTAPI.Modifications/OTAPI.Modifications.NetCore/System.Windows.Forms/FormWindowState.cs
+++ b/OTAPI.Modifications/OTAPI.Modifications.NetCore/System.Windows.Forms/FormWindowState.cs
@@ -1,0 +1,9 @@
+﻿namespace System.Windows.Forms
+{
+	public enum FormWindowState
+	{
+		Normal = 0,
+		Minimized = 1,
+		Maximized = 2
+	}
+}

--- a/OTAPI.Modifications/OTAPI.Modifications.NetCore/System.Windows.Forms/IMessageFilter.cs
+++ b/OTAPI.Modifications/OTAPI.Modifications.NetCore/System.Windows.Forms/IMessageFilter.cs
@@ -1,0 +1,7 @@
+﻿namespace System.Windows.Forms
+{
+	public interface IMessageFilter
+	{
+		bool PreFilterMessage(ref Message m);
+	}
+}

--- a/OTAPI.Modifications/OTAPI.Modifications.NetCore/System.Windows.Forms/Message.cs
+++ b/OTAPI.Modifications/OTAPI.Modifications.NetCore/System.Windows.Forms/Message.cs
@@ -1,0 +1,12 @@
+﻿namespace System.Windows.Forms
+{
+	public struct Message
+	{
+		public IntPtr HWnd { get; set; }
+		public int Msg { get; set; }
+		public IntPtr WParam { get; set; }
+		public IntPtr LParam { get; set; }
+
+		public static Message Create(IntPtr hWnd, int msg, IntPtr wparam, IntPtr lparam) => new Message();
+	}
+}

--- a/OTAPI.Modifications/OTAPI.Modifications.NetCore/packages.config
+++ b/OTAPI.Modifications/OTAPI.Modifications.NetCore/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="Mono.Cecil" version="0.9.6.4" targetFramework="net451" />
+</packages>

--- a/OTAPI.Server.sln
+++ b/OTAPI.Server.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27004.2002
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29318.209
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documents", "Documents", "{2CA8A2CD-657F-499E-92C2-B2E0AC5488C4}"
 	ProjectSection(SolutionItems) = preProject
@@ -183,6 +183,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OTAPI.Modifications.Net.NetworkText", "OTAPI.Modifications\OTAPI.Modifications.Net.NetworkText\OTAPI.Modifications.Net.NetworkText.csproj", "{C2F5A2DE-8A37-4633-96B4-2F636B8A028E}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OTAPI.Modifications.World.SpreadGrass", "OTAPI.Modifications\OTAPI.Modifications.World.SpreadGrass\OTAPI.Modifications.World.SpreadGrass.csproj", "{BD68AE57-0E7B-484F-9F90-57194FF0BF94}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OTAPI.Modifications.NetCore", "OTAPI.Modifications\OTAPI.Modifications.NetCore\OTAPI.Modifications.NetCore.csproj", "{C805D018-48D3-4B93-BED7-99C7ECD8837C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -938,6 +940,18 @@ Global
 		{BD68AE57-0E7B-484F-9F90-57194FF0BF94}.Server-Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BD68AE57-0E7B-484F-9F90-57194FF0BF94}.Server-Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BD68AE57-0E7B-484F-9F90-57194FF0BF94}.Server-Release|Any CPU.Build.0 = Release|Any CPU
+		{C805D018-48D3-4B93-BED7-99C7ECD8837C}.Client-Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C805D018-48D3-4B93-BED7-99C7ECD8837C}.Client-Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C805D018-48D3-4B93-BED7-99C7ECD8837C}.Client-Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C805D018-48D3-4B93-BED7-99C7ECD8837C}.Client-Release|Any CPU.Build.0 = Release|Any CPU
+		{C805D018-48D3-4B93-BED7-99C7ECD8837C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C805D018-48D3-4B93-BED7-99C7ECD8837C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C805D018-48D3-4B93-BED7-99C7ECD8837C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C805D018-48D3-4B93-BED7-99C7ECD8837C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C805D018-48D3-4B93-BED7-99C7ECD8837C}.Server-Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C805D018-48D3-4B93-BED7-99C7ECD8837C}.Server-Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C805D018-48D3-4B93-BED7-99C7ECD8837C}.Server-Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C805D018-48D3-4B93-BED7-99C7ECD8837C}.Server-Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1023,6 +1037,7 @@ Global
 		{0B5AD12E-3ED4-42EF-B5F6-7F082C96326D} = {33765E63-95ED-40A7-BDB0-418BDA698C32}
 		{C2F5A2DE-8A37-4633-96B4-2F636B8A028E} = {936CBC51-EB4E-4381-B992-AC7D9D4DBB7F}
 		{BD68AE57-0E7B-484F-9F90-57194FF0BF94} = {D6DE4652-8079-493E-B6F0-220A24D96B7B}
+		{C805D018-48D3-4B93-BED7-99C7ECD8837C} = {6F612C0E-1D67-4E06-8FB2-0D372CA5C264}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {543F33EE-BF64-4D6A-9F08-463CDCF68762}

--- a/prebuild.ps1
+++ b/prebuild.ps1
@@ -63,7 +63,7 @@ Catch
 
 #Find the zip url in the html content
 $html = [System.IO.File]::ReadAllText($terrariaHtml);
-$indexor = $html.LastIndexOf('>Dedicated Server</a>');
+$indexor = $html.LastIndexOf('>PC Dedicated Server</a>');
 
 If($indexor -eq -1)
 {


### PR DESCRIPTION
This pull request makes OTAPI easier to run with .NET core. Basically, it will do the following:

- Use `File.Delete` instead of `shell32.dll` for *all* platforms, not just Mono
- Replace `System.Windows.Forms` with our own mock
- Replace `WindowsBase` with our own mock

Additionally, I have updated the travis script and the prebuild script to take the proper `TerrariaServer.exe` now.