### PR TITLE
Add additional search path for game installs within `LinuxInstallDiscoverer`

### DIFF
--- a/OTAPI.Common/LinuxInstallDiscoverer.cs
+++ b/OTAPI.Common/LinuxInstallDiscoverer.cs
@@ -26,6 +26,7 @@ namespace OTAPI.Common
         public override string[] SearchPaths { get; } = new[]
         {
             "/home/[USER_NAME]/.steam/debian-installation/steamapps/common/Terraria",
+            "/home/[USER_NAME]/.steam/steam/steamapps/common/Terraria",
         };
 
         public override OSPlatform GetClientPlatform() => OSPlatform.Linux;


### PR DESCRIPTION
This is what the path is on my system.
```
$ uname -a
Linux JAMES-DESKTOP 5.10.41-1-MANJARO #1 SMP PREEMPT Fri May 28 19:10:32 UTC 2021 x86_64 GNU/Linux
```