### PR TITLE
Injecting a temporary SendData method until next hotfix.

### DIFF
--- a/OTAPI.Modifications/OTAPI.Modifications.Net.SendData/Callbacks/SendData.cs
+++ b/OTAPI.Modifications/OTAPI.Modifications.Net.SendData/Callbacks/SendData.cs
@@ -15,7 +15,7 @@
             ref int number5,
             ref int number6,
             ref int number7,
-			ref int number8
+			ref float number8
         )
         {
             //Since we currently wrap the method we need to run these checks

--- a/OTAPI.Modifications/OTAPI.Modifications.Net.SendData/Modifications/SendData.cs
+++ b/OTAPI.Modifications/OTAPI.Modifications.Net.SendData/Modifications/SendData.cs
@@ -19,7 +19,7 @@ namespace OTAPI.Patcher.Engine.Modifications.Hooks.Net
 
             var vanilla = this.Method(() => Terraria.NetMessage.SendData(0, -1, -1, Terraria.Localization.NetworkText.Empty, 0, 0, 0, 0, 0, 0, 0, 0));
             var callback = this.Method(() => OTAPI.Callbacks.Terraria.NetMessage.SendData(
-                ref tmpI, ref tmpI, ref tmpI, ref tmpS, ref tmpI, ref tmpF, ref tmpF, ref tmpF, ref tmpI, ref tmpI, ref tmpI, ref tmpI
+                ref tmpI, ref tmpI, ref tmpI, ref tmpS, ref tmpI, ref tmpF, ref tmpF, ref tmpF, ref tmpI, ref tmpI, ref tmpI, ref tmpF
             ));
 
             //Few stack issues arose trying to inject a callback before for lock, so i'll resort to 

--- a/OTAPI.Modifications/OTAPI.Modifications.Net.SendData/Modifications/SendDataTemp.cs
+++ b/OTAPI.Modifications/OTAPI.Modifications.Net.SendData/Modifications/SendDataTemp.cs
@@ -1,0 +1,51 @@
+﻿using Mono.Cecil;
+using Mono.Cecil.Cil;
+using OTAPI.Patcher.Engine.Extensions;
+using OTAPI.Patcher.Engine.Modification;
+using System.Linq;
+
+namespace OTAPI.Patcher.Engine.Modifications.Hooks.Net
+{
+    public class SendDataTemp : ModificationBase
+    {
+        public override System.Collections.Generic.IEnumerable<string> AssemblyTargets => new[]
+        {
+            "TerrariaServer, Version=1.4.3.0, Culture=neutral, PublicKeyToken=null"
+        };
+        public override string Description => "Injecting a temporary 11 param NetMessage.SendData...";
+
+        public override void Run()
+        {
+            var vanilla = this.SourceDefinition.Type("Terraria.NetMessage").Methods.Single(m => m.Name == "SendData");
+            vanilla.IsAssembly = true;
+
+            // Define the new SendData method.
+            var sendDataTemp = new MethodDefinition("SendData", MethodAttributes.Public | MethodAttributes.Static, this.SourceDefinition.MainModule.TypeSystem.Void);
+
+            var il = sendDataTemp.Body.GetILProcessor();
+            il.Append(il.Create(OpCodes.Nop));
+
+            // Iterate through the parameters of the original (new) SendData, and we add/clone them to our new method.
+            foreach (var var in vanilla.Parameters)
+            {
+                if (var.Name == "number8")
+                    continue;
+                sendDataTemp.Parameters.Add(var);
+                //Load the parameter value onto the stack.
+                il.Emit(OpCodes.Ldarg, var);
+            }
+            // Load a 0 onto the stack as the last variable.
+            il.Emit(OpCodes.Ldc_I4, 0);
+
+            // Create the method call of the OG SendData.
+            var sendDataMethodCall = il.Create(OpCodes.Call, vanilla);
+            il.Append(sendDataMethodCall);
+
+            il.Append(il.Create(OpCodes.Nop));
+            il.Append(il.Create(OpCodes.Ret));
+
+            // Add our method to the NetMessage class.
+            vanilla.DeclaringType.Methods.Add(sendDataTemp);
+        }
+    }
+}

--- a/OTAPI.Modifications/OTAPI.Modifications.Net.SendData/OTAPI.Modifications.Net.SendData.csproj
+++ b/OTAPI.Modifications/OTAPI.Modifications.Net.SendData/OTAPI.Modifications.Net.SendData.csproj
@@ -48,6 +48,7 @@
   <ItemGroup>
     <Compile Include="Callbacks\SendData.cs" />
     <Compile Include="Hooks\SendData.cs" />
+    <Compile Include="Modifications\SendDataTemp.cs" />
     <Compile Include="Modifications\SendData.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/OTAPI.Modifications/OTAPI.Modifications.Net.SendUnknownPacket/Callbacks/SendUnknownPacket.cs
+++ b/OTAPI.Modifications/OTAPI.Modifications.Net.SendUnknownPacket/Callbacks/SendUnknownPacket.cs
@@ -17,7 +17,7 @@
 			int number5,
 			int number6,
 			int number7,
-			int number8
+            float number8
 		)
 		{
 			Hooks.Net.SendUnknownPacket?.Invoke


### PR DESCRIPTION
The dev team has added an additional parameter to SendData and SendDataDirect, which is unused and will be removed in the next hotfix. To avoid having to update all plugins - as they would look for the 11 parameter length version of SendData - we set SendData to internal to avoid ambiguity, and injected another.

For reasons (Death knows better( SendDataDirect also turns internal as we set SendData, so the hotfix for this, is to adjust a line in TSAPI SSC modification.