### PR TITLE
Support Terraria 1.4.3.2 + bump nuspec package

### DIFF
--- a/OTAPI.Patcher/OTAPI.Patcher.csproj
+++ b/OTAPI.Patcher/OTAPI.Patcher.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net5.0</TargetFramework>
-		<Version>3.0.23-alpha</Version>
+		<Version>3.0.24-alpha</Version>
 		<PreserveCompilationContext>true</PreserveCompilationContext>
 		<PlatformTarget>x64</PlatformTarget>
 		<RuntimeIdentifiers>win7-x64;osx.10.11-x64;ubuntu.16.04-x64</RuntimeIdentifiers>

--- a/OTAPI.Patcher/Targets/OTAPIPCServerTarget.cs
+++ b/OTAPI.Patcher/Targets/OTAPIPCServerTarget.cs
@@ -44,7 +44,7 @@ namespace OTAPI.Patcher.Targets
         public virtual string NuSpecFilePath { get; } = "../../../../docs/OTAPI.PC.nuspec";
         public virtual string MdFileName { get; } = "OTAPI.PC.Server.mfw.md";
 
-        public virtual string SupportedDownloadUrl { get; } = $"{TerrariaWebsite}/api/download/pc-dedicated-server/terraria-server-1431.zip";
+        public virtual string SupportedDownloadUrl { get; } = $"{TerrariaWebsite}/api/download/pc-dedicated-server/terraria-server-1432.zip";
         public virtual string ArtifactName { get; } = "artifact-pc";
 
         private MarkdownDocumentor markdownDocumentor = new ModificationMdDocumentor();

--- a/docs/OTAPI.PC.nuspec
+++ b/docs/OTAPI.PC.nuspec
@@ -24,9 +24,9 @@
          - A strong set of libraries with methods and extensions to help you build more mods.
          - Create 1 file MonoMod patches to rewrite or inject new meta data to the assembly.
     </description>
-    <summary>Open Terraria API [INJECT_VERSION] for Terraria 1.4.3.1[INJECT_GIT_HASH]</summary>
+    <summary>Open Terraria API [INJECT_VERSION] for Terraria 1.4.3.2[INJECT_GIT_HASH]</summary>
     <releaseNotes>
-      Preliminary Terraria 1.4.3.1
+      Preliminary Terraria 1.4.3.2
     </releaseNotes>
     <copyright>Copyright 2016-2021</copyright>
     <tags>Terraria,OTAPI</tags>


### PR DESCRIPTION
Adds support for 1.4.3.2 + related maintenance stuff for otapi3 to be on fancy new Terraria, in a hypothetical world.