### PR TITLE
Introduce `1.4.4.5` support, bumping to `3.1.9-alpha`

### DIFF
--- a/OTAPI.Patcher/OTAPI.Patcher.csproj
+++ b/OTAPI.Patcher/OTAPI.Patcher.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net6.0</TargetFramework>
-		<Version>3.1.8-alpha</Version>
+		<Version>3.1.9-alpha</Version>
 		<PreserveCompilationContext>true</PreserveCompilationContext>
 		<PlatformTarget>x64</PlatformTarget>
 		<RuntimeIdentifiers>win7-x64;osx.10.11-x64;ubuntu.16.04-x64</RuntimeIdentifiers>

--- a/OTAPI.Patcher/Resolvers/PCFileResolver.cs
+++ b/OTAPI.Patcher/Resolvers/PCFileResolver.cs
@@ -28,7 +28,7 @@ public class PCFileResolver : IFileResolver
 {
     public const String TerrariaWebsite = "https://terraria.org";
 
-    public virtual string SupportedDownloadUrl { get; } = $"{TerrariaWebsite}/api/download/pc-dedicated-server/terraria-server-1444.zip";
+    public virtual string SupportedDownloadUrl { get; } = $"{TerrariaWebsite}/api/download/pc-dedicated-server/terraria-server-1445.zip";
 
     public virtual string GetUrlFromHttpResponse(string content)
     {


### PR DESCRIPTION
Builds just fine, using this for a custom-gamemode server with at least 30 people, seems to be no issues relating to this.