### PR TITLE
Update to 3.1.16 to support Terraria 1.4.4.7

### DIFF
--- a/OTAPI.Patcher/OTAPI.Patcher.csproj
+++ b/OTAPI.Patcher/OTAPI.Patcher.csproj
@@ -3,12 +3,12 @@
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net6.0</TargetFramework>
-		<Version>3.1.15</Version>
+		<Version>3.1.16</Version>
 		<PreserveCompilationContext>true</PreserveCompilationContext>
 		<PlatformTarget>x64</PlatformTarget>
 		<RuntimeIdentifiers>win7-x64;osx.10.11-x64;ubuntu.16.04-x64</RuntimeIdentifiers>
 		<Nullable>enable</Nullable>
-		<PackageReleaseNotes>Initial Terraria 1.4.4.6 support</PackageReleaseNotes>
+		<PackageReleaseNotes>Initial Terraria 1.4.4.7 support</PackageReleaseNotes>
 	</PropertyGroup>
 	<ItemGroup>
     <PackageReference Include="ModFramework.Modules.ClearScript" Version="1.1.6" />

--- a/OTAPI.Patcher/Resolvers/PCFileResolver.cs
+++ b/OTAPI.Patcher/Resolvers/PCFileResolver.cs
@@ -28,7 +28,7 @@ public class PCFileResolver : IFileResolver
 {
     public const String TerrariaWebsite = "https://terraria.org";
 
-    public virtual string SupportedDownloadUrl { get; } = $"{TerrariaWebsite}/api/download/pc-dedicated-server/terraria-server-1446-fixed.zip";
+    public virtual string SupportedDownloadUrl { get; } = $"{TerrariaWebsite}/api/download/pc-dedicated-server/terraria-server-1447.zip";
 
     public virtual string GetUrlFromHttpResponse(string content)
     {


### PR DESCRIPTION
Carbon copy of changes that are done for all other hotfixes