### PR TITLE
Simplify CI

### DIFF
--- a/.github/workflows/ci-launcher.yml
+++ b/.github/workflows/ci-launcher.yml
@@ -1,5 +1,3 @@
-# This is a basic workflow to help you get started with Actions
-
 name: "CI-Launcher"
 
 # Controls when the workflow will run
@@ -17,10 +15,43 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build_win:
-    # The type of runner that the job will run on
-    runs-on: windows-latest
+  build:
+    strategy:
+      matrix:
+        profile: [
+          {
+            name: Windows,
+            runs_on: windows-latest,
+
+            runtime_identifier: win-x64,
+            archive_name: otapi_launcher_win.zip,
+
+            release_tag: launcher-windows,
+          },
+          {
+            name: MacOS,
+            runs_on: macos-latest,
+
+            runtime_identifier: osx-x64,
+            archive_name: otapi_launcher_macos.zip,
+
+            release_tag: launcher-macos,
+          },
+          {
+            name: Linux,
+            runs_on: ubuntu-latest,
+
+            runtime_identifier: ubuntu.16.04-x64,
+            archive_name: otapi_launcher_linux.zip,
+
+            release_tag: launcher-linux,
+          },
+        ]
+    name: Build ${{ matrix.profile.name }}
+    defaults:
+      run:
+        shell: bash
+    runs-on: ${{ matrix.profile.runs_on }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -36,103 +67,32 @@ jobs:
       # - name: MonoMod dev build
       #   run: dotnet nuget add source https://pkgs.dev.azure.com/MonoMod/MonoMod/_packaging/DevBuilds%40Local/nuget/v3/index.json -n DevBuilds@Local
 
-      - name: Build and publish windows
+      - name: Build
         run: |
             cd OTAPI.Client.Launcher
-            dotnet publish -r win-x64 --framework net6.0 -p:PublishReadyToRun=true --self-contained false -c Release
-            Compress-Archive bin/Release/net6.0/win-x64/publish ../otapi_launcher_win.zip
+            dotnet publish -r ${{ matrix.profile.runtime_identifier }} --framework net6.0 -p:PublishReadyToRun=true --self-contained false -c Release
+            if ${{ matrix.profile.runs_on != 'macos-latest' }} ; then
+              7z a ../${{ matrix.profile.archive_name }} './bin/Release/net6.0/${{ matrix.profile.runtime_identifier }}/publish/*'
+            else
+              mkdir -p OTAPI.app/Contents/Resources
+              mv bin/Release/net6.0/osx-x64/publish OTAPI.app/Contents/MacOS
+              cp ../docs/MacOS.Info.plist OTAPI.app/Contents/Info.plist
+              cp OTAPI.osx.sh OTAPI.app/Contents/MacOS/OTAPI
+              chmod +x OTAPI.app/Contents/MacOS/OTAPI
+              7z a ../${{ matrix.profile.archive_name }} OTAPI.app
+            fi
 
       # - uses: actions/upload-artifact@v2
       #   with:
-      #     name: Windows Launcher
-      #     path: OTAPI.Client.Launcher/bin/Release/net6.0/win-x64/publish
+      #     name: ${{ matrix.profile.name }} Launcher
+      #     path: OTAPI.Client.Launcher/bin/Release/net6.0/${{ matrix.profile.runtime_identifier }}/publish
 
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "launcher-windows"
+          automatic_release_tag: ${{ matrix.profile.release_tag }}
           prerelease: true
-          title: "Windows Launcher"
+          title: "${{ matrix.profile.name }} Launcher"
           files: |
             LICENSE.txt
-            otapi_launcher_win.zip
-
-  build_osx:
-    # The type of runner that the job will run on
-    runs-on: macos-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
-        with:
-          submodules: 'recursive'
-
-      - uses: actions/setup-dotnet@v2
-        with:
-          dotnet-version: '6.0.x' # SDK Version to use; x will use the latest version of the 3.1 channel
-
-      - name: Build and publish macos
-        run: |
-            cd OTAPI.Client.Launcher
-            dotnet publish -r osx-x64 --framework net6.0 -p:PublishReadyToRun=true --self-contained false -c Release
-            mkdir OTAPI.app
-            mkdir OTAPI.app/Contents
-            mkdir OTAPI.app/Contents/Resources
-            mv bin/Release/net6.0/osx-x64/publish OTAPI.app/Contents/MacOS
-            cp ../docs/MacOS.Info.plist OTAPI.app/Contents/Info.plist
-            cp OTAPI.osx.sh OTAPI.app/Contents/MacOS/OTAPI
-            chmod +x OTAPI.app/Contents/MacOS/OTAPI
-            zip -r ../otapi_launcher_macos.zip OTAPI.app
-
-      # - uses: actions/upload-artifact@v2
-      #   with:
-      #     name: MacOS Launcher
-      #     path: OTAPI.Client.Launcher/bin/Release/net6.0/osx.10.11-x64/publish
-
-      - uses: "marvinpinto/action-automatic-releases@latest"
-        with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "launcher-macos"
-          prerelease: true
-          title: "MacOS Launcher"
-          files: |
-            LICENSE.txt
-            otapi_launcher_macos.zip
-
-  # This workflow contains a single job called "build"
-  build_lin:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
-        with:
-          submodules: 'recursive'
-
-      - uses: actions/setup-dotnet@v2
-        with:
-          dotnet-version: '6.0.x' # SDK Version to use; x will use the latest version of the 3.1 channel
-
-      - name: Build and publish linux
-        run: |
-            cd OTAPI.Client.Launcher
-            dotnet publish -r ubuntu.16.04-x64 --framework net6.0 -p:PublishReadyToRun=true --self-contained false -c Release
-            zip -r ../otapi_launcher_linux.zip bin/Release/net6.0/ubuntu.16.04-x64/publish
-
-      # - uses: actions/upload-artifact@v2
-      #   with:
-      #     name: Linux Launcher
-      #     path: OTAPI.Client.Launcher/bin/Release/net6.0/ubuntu.16.04-x64/publish
-
-      - uses: "marvinpinto/action-automatic-releases@latest"
-        with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "launcher-linux"
-          prerelease: true
-          title: "Linux Launcher"
-          files: |
-            LICENSE.txt
-            otapi_launcher_linux.zip
+            ${{ matrix.profile.archive_name }}

--- a/.github/workflows/ci-nuget.yml
+++ b/.github/workflows/ci-nuget.yml
@@ -1,5 +1,3 @@
-# This is a basic workflow to help you get started with Actions
-
 name: "CI-NuGet"
 
 # Controls when the workflow will run
@@ -7,149 +5,67 @@ on:
   # Triggers the workflow on push/pull events but only for the upcoming-nuget-release branch
   push:
     branches: [ upcoming-nuget-release ]
-    
+
 jobs:
 
-  PCServer:
+  Server:
     runs-on: ubuntu-latest
     environment: CI
-    
+
+    strategy:
+      fail-fast: false
+      matrix:
+        profile: [
+          {
+            name: PC,
+            patch_target: p,
+            package_path: OTAPI.PC.nupkg,
+          },
+          {
+            name: Mobile,
+            patch_target: m,
+            package_path: OTAPI.Mobile.nupkg,
+          },
+          {
+            name: tModLoader,
+            patch_target: t,
+            package_path: OTAPI.TML.nupkg,
+          },
+        ]
+
+    name: ${{ matrix.profile.name }} Server
+
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: 'recursive'
 
-      - uses: actions/setup-dotnet@v2
+      - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.x'
 
       - name: Build the project
         run: |
-          dotnet restore OTAPI.Mods.sln
-          dotnet restore OTAPI.Server.Launcher.sln
-          dotnet build OTAPI.Mods.sln
-          cd OTAPI.Patcher/bin/Debug/net6.0
-          dotnet run --project ../../../OTAPI.Patcher.csproj -patchTarget=p -latest=n --framework net6.0
-          cd ../../../../
-          dotnet build OTAPI.Server.Launcher.sln
-          cd OTAPI.Server.Launcher/bin/Debug/net6.0
-          dotnet OTAPI.Server.Launcher.dll -test-init
+          (cd OTAPI.Patcher && exec dotnet run -patchTarget=${{ matrix.profile.patch_target }} -latest=n --framework net6.0)
+          (cd OTAPI.Server.Launcher && exec dotnet run -test-init)
 
       - uses: actions/upload-artifact@v3
         with:
-          name: PC NuGet Package
-          path:  OTAPI.Patcher/bin/Debug/net6.0/OTAPI.PC.nupkg
+          name: ${{ matrix.profile.name }} NuGet Package
+          path: OTAPI.Patcher/bin/Debug/net6.0/${{ matrix.profile.package_path }}
 
       - uses: actions/upload-artifact@v3
         with:
-          name: PC Binaries
+          name: ${{ matrix.profile.name }} Binaries
           path: |
-            OTAPI.Patcher/bin/Debug/net6.0/artifact-pc/COPYING.txt
-            OTAPI.Patcher/bin/Debug/net6.0/artifact-pc/OTAPI.dll
-            OTAPI.Patcher/bin/Debug/net6.0/artifact-pc/OTAPI.Runtime.dll
+            OTAPI.Patcher/bin/Debug/net6.0/artifact-*/*
 
       - uses: actions/upload-artifact@v3
         with:
-          name: PC Wiki MD files
-          path: OTAPI.Patcher/bin/Debug/net6.0/OTAPI.PC.Server.mfw.md
+          name: ${{ matrix.profile.name }} Wiki MD files
+          path: OTAPI.Patcher/bin/Debug/net6.0/*.mfw.md
 
-      - name: "Releasing to NuGet: OTAPI.Upcoming"
+      - name: "Releasing to NuGet: ${{ matrix.profile.name }}"
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-        run: dotnet nuget push OTAPI.Patcher/bin/Debug/net6.0/OTAPI.PC.nupkg --source https://api.nuget.org/v3/index.json --api-key "$NUGET_API_KEY"
-
-  MobileServer:
-    runs-on: ubuntu-latest
-    environment: CI
-    
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: 'recursive'
-
-      - uses: actions/setup-dotnet@v2
-        with:
-          dotnet-version: '6.0.x'
-
-      - name: Build the project
-        run: |
-          dotnet restore OTAPI.Mods.sln
-          dotnet restore OTAPI.Server.Launcher.sln
-          dotnet build OTAPI.Mods.sln
-          cd OTAPI.Patcher/bin/Debug/net6.0
-          dotnet run --project ../../../OTAPI.Patcher.csproj -patchTarget=m -latest=n --framework net6.0
-          cd ../../../../
-          dotnet build OTAPI.Server.Launcher.sln
-          cd OTAPI.Server.Launcher/bin/Debug/net6.0
-          dotnet OTAPI.Server.Launcher.dll -test-init
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: Mobile NuGet Package
-          path: OTAPI.Patcher/bin/Debug/net6.0/OTAPI.Mobile.nupkg
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: Mobile Binaries
-          path: |
-            OTAPI.Patcher/bin/Debug/net6.0/artifact-mobile/COPYING.txt
-            OTAPI.Patcher/bin/Debug/net6.0/artifact-mobile/OTAPI.dll
-            OTAPI.Patcher/bin/Debug/net6.0/artifact-mobile/OTAPI.Runtime.dll
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: Mobile Wiki MD files
-          path: OTAPI.Patcher/bin/Debug/net6.0/OTAPI.Mobile.Server.mfw.md
-
-      - name: "Releasing to NuGet: OTAPI.Upcoming.Mobile"
-        env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-        run: dotnet nuget push OTAPI.Patcher/bin/Debug/net6.0/OTAPI.Mobile.nupkg --source https://api.nuget.org/v3/index.json --api-key "$NUGET_API_KEY"
-
-  tModLoaderServer:
-    runs-on: ubuntu-latest
-    environment: CI
-    
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: 'recursive'
-
-      - uses: actions/setup-dotnet@v2
-        with:
-          dotnet-version: '6.0.x'
-
-      - name: Build the project
-        run: |
-          dotnet restore OTAPI.Mods.sln
-          dotnet restore OTAPI.Server.Launcher.sln
-          dotnet build OTAPI.Mods.sln
-          cd OTAPI.Patcher/bin/Debug/net6.0
-          dotnet run --project ../../../OTAPI.Patcher.csproj -patchTarget=t -latest=n --framework net6.0
-          cd ../../../../
-          dotnet build OTAPI.Server.Launcher.sln
-          cd OTAPI.Server.Launcher/bin/Debug/net6.0
-          dotnet OTAPI.Server.Launcher.dll -test-init
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: tModLoader NuGet Package
-          path: OTAPI.Patcher/bin/Debug/net6.0/OTAPI.TML.nupkg
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: tModLoader Binaries
-          path: |
-            OTAPI.Patcher/bin/Debug/net6.0/artifact-tml/COPYING.txt
-            OTAPI.Patcher/bin/Debug/net6.0/artifact-tml/OTAPI.dll
-            OTAPI.Patcher/bin/Debug/net6.0/artifact-tml/OTAPI.Runtime.dll
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: tModLoader Wiki MD files
-          path: OTAPI.Patcher/bin/Debug/net6.0/OTAPI.TML.PC.Server.mfw.md
-          
-      - name: "Releasing to NuGet: OTAPI.Upcoming.tModLoader"
-        env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-        run: dotnet nuget push OTAPI.Patcher/bin/Debug/net6.0/OTAPI.TML.nupkg --source https://api.nuget.org/v3/index.json --api-key "$NUGET_API_KEY"
+        run: dotnet nuget push OTAPI.Patcher/bin/Debug/net6.0/${{ matrix.profile.package_path }} --source https://api.nuget.org/v3/index.json --api-key "$NUGET_API_KEY"

--- a/.github/workflows/ci-nuget.yml
+++ b/.github/workflows/ci-nuget.yml
@@ -46,8 +46,10 @@ jobs:
 
       - name: Build the project
         run: |
-          (cd OTAPI.Patcher && exec dotnet run -patchTarget=${{ matrix.profile.patch_target }} -latest=n --framework net6.0)
-          (cd OTAPI.Server.Launcher && exec dotnet run -test-init)
+          dotnet build OTAPI.Mods.sln
+          (cd OTAPI.Patcher/bin/Debug/net6.0 && exec dotnet run --project ../../../OTAPI.Patcher.csproj -patchTarget=${{ matrix.profile.patch_target }} -latest=n --framework net6.0)
+          dotnet build OTAPI.Server.Launcher.sln
+          (cd OTAPI.Server.Launcher/bin/Debug/net6.0 && exec dotnet OTAPI.Server.Launcher.dll -test-init)
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,3 @@
-# This is a basic workflow to help you get started with Actions
-
 name: CI
 
 # Controls when the workflow will run
@@ -16,129 +14,58 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
 
-  PCServer:
+  Server:
     runs-on: ubuntu-latest
-    
+
+    strategy:
+      fail-fast: false
+      matrix:
+        profile: [
+          {
+            name: PC,
+            patch_target: p,
+            package_path: OTAPI.PC.nupkg,
+          },
+          {
+            name: Mobile,
+            patch_target: m,
+            package_path: OTAPI.Mobile.nupkg,
+          },
+          {
+            name: tModLoader,
+            patch_target: t,
+            package_path: OTAPI.TML.nupkg,
+          },
+        ]
+
+    name: ${{ matrix.profile.name }} Server
+
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: 'recursive'
 
-      - uses: actions/setup-dotnet@v2
+      - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.x'
 
       - name: Build the project
         run: |
-          dotnet restore OTAPI.Mods.sln
-          dotnet restore OTAPI.Server.Launcher.sln
-          dotnet build OTAPI.Mods.sln
-          cd OTAPI.Patcher/bin/Debug/net6.0
-          dotnet run --project ../../../OTAPI.Patcher.csproj -patchTarget=p -latest=n --framework net6.0
-          cd ../../../../
-          dotnet build OTAPI.Server.Launcher.sln
-          cd OTAPI.Server.Launcher/bin/Debug/net6.0
-          dotnet OTAPI.Server.Launcher.dll -test-init
+          (cd OTAPI.Patcher && exec dotnet run -patchTarget=${{ matrix.profile.patch_target }} -latest=n --framework net6.0)
+          (cd OTAPI.Server.Launcher && exec dotnet run -test-init)
 
       - uses: actions/upload-artifact@v3
         with:
-          name: PC NuGet Package
-          path:  OTAPI.Patcher/bin/Debug/net6.0/OTAPI.PC.nupkg
+          name: ${{ matrix.profile.name }} NuGet Package
+          path: OTAPI.Patcher/bin/Debug/net6.0/${{ matrix.profile.package_path }}
 
       - uses: actions/upload-artifact@v3
         with:
-          name: PC Binaries
+          name: ${{ matrix.profile.name }} Binaries
           path: |
-            OTAPI.Patcher/bin/Debug/net6.0/artifact-pc/COPYING.txt
-            OTAPI.Patcher/bin/Debug/net6.0/artifact-pc/OTAPI.dll
-            OTAPI.Patcher/bin/Debug/net6.0/artifact-pc/OTAPI.Runtime.dll
+            OTAPI.Patcher/bin/Debug/net6.0/artifact-*/*
 
       - uses: actions/upload-artifact@v3
         with:
-          name: PC Wiki MD files
-          path: OTAPI.Patcher/bin/Debug/net6.0/OTAPI.PC.Server.mfw.md
-
-  MobileServer:
-    runs-on: ubuntu-latest
-    
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: 'recursive'
-
-      - uses: actions/setup-dotnet@v2
-        with:
-          dotnet-version: '6.0.x'
-
-      - name: Build the project
-        run: |
-          dotnet restore OTAPI.Mods.sln
-          dotnet restore OTAPI.Server.Launcher.sln
-          dotnet build OTAPI.Mods.sln
-          cd OTAPI.Patcher/bin/Debug/net6.0
-          dotnet run --project ../../../OTAPI.Patcher.csproj -patchTarget=m -latest=n --framework net6.0
-          cd ../../../../
-          dotnet build OTAPI.Server.Launcher.sln
-          cd OTAPI.Server.Launcher/bin/Debug/net6.0
-          dotnet OTAPI.Server.Launcher.dll -test-init
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: Mobile NuGet Package
-          path: OTAPI.Patcher/bin/Debug/net6.0/OTAPI.Mobile.nupkg
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: Mobile Binaries
-          path: |
-            OTAPI.Patcher/bin/Debug/net6.0/artifact-mobile/COPYING.txt
-            OTAPI.Patcher/bin/Debug/net6.0/artifact-mobile/OTAPI.dll
-            OTAPI.Patcher/bin/Debug/net6.0/artifact-mobile/OTAPI.Runtime.dll
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: Mobile Wiki MD files
-          path: OTAPI.Patcher/bin/Debug/net6.0/OTAPI.Mobile.Server.mfw.md
-
-  tModLoaderServer:
-    runs-on: ubuntu-latest
-    
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: 'recursive'
-
-      - uses: actions/setup-dotnet@v2
-        with:
-          dotnet-version: '6.0.x'
-
-      - name: Build the project
-        run: |
-          dotnet restore OTAPI.Mods.sln
-          dotnet restore OTAPI.Server.Launcher.sln
-          dotnet build OTAPI.Mods.sln
-          cd OTAPI.Patcher/bin/Debug/net6.0
-          dotnet run --project ../../../OTAPI.Patcher.csproj -patchTarget=t -latest=n --framework net6.0
-          cd ../../../../
-          dotnet build OTAPI.Server.Launcher.sln
-          cd OTAPI.Server.Launcher/bin/Debug/net6.0
-          dotnet OTAPI.Server.Launcher.dll -test-init
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: tModLoader NuGet Package
-          path: OTAPI.Patcher/bin/Debug/net6.0/OTAPI.TML.nupkg
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: tModLoader Binaries
-          path: |
-            OTAPI.Patcher/bin/Debug/net6.0/artifact-tml/COPYING.txt
-            OTAPI.Patcher/bin/Debug/net6.0/artifact-tml/OTAPI.dll
-            OTAPI.Patcher/bin/Debug/net6.0/artifact-tml/OTAPI.Runtime.dll
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: tModLoader Wiki MD files
-          path: OTAPI.Patcher/bin/Debug/net6.0/OTAPI.TML.PC.Server.mfw.md
-            
+          name: ${{ matrix.profile.name }} Wiki MD files
+          path: OTAPI.Patcher/bin/Debug/net6.0/*.mfw.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,10 @@ jobs:
 
       - name: Build the project
         run: |
-          (cd OTAPI.Patcher && exec dotnet run -patchTarget=${{ matrix.profile.patch_target }} -latest=n --framework net6.0)
-          (cd OTAPI.Server.Launcher && exec dotnet run -test-init)
+          dotnet build OTAPI.Mods.sln
+          (cd OTAPI.Patcher/bin/Debug/net6.0 && exec dotnet run --project ../../../OTAPI.Patcher.csproj -patchTarget=${{ matrix.profile.patch_target }} -latest=n --framework net6.0)
+          dotnet build OTAPI.Server.Launcher.sln
+          (cd OTAPI.Server.Launcher/bin/Debug/net6.0 && exec dotnet OTAPI.Server.Launcher.dll -test-init)
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
- Simplified CI by deduplicating jobs using Actions' matrixes
- Unified zipping program to 7z(it is installed in all three runners Actions supports)
- Fixed Windows' Launcher zip starting with `publish`
- Fixed Linux's launcher zip starting with `bin/Release/net6.0/ubuntu.16.04-x64/publish`