### PR TITLE
Fix HookCommandProcessing not working in v1.4.5

### DIFF
--- a/OTAPI.Scripts/Mods/HookCommandProcessing.Server.cs
+++ b/OTAPI.Scripts/Mods/HookCommandProcessing.Server.cs
@@ -39,13 +39,18 @@ void HookCommandProcessing(MonoModder modder)
     var startDedInputCallBack = modder.GetILCursor(() => Terraria.Main.startDedInputCallBack());
 
     var vText = startDedInputCallBack.Body.Variables[0];
+#if TerrariaServer_1450_OrAbove || Terraria__1450_OrAbove || tModLoader_1450_OrAbove
+#else
     var vTextLowered = startDedInputCallBack.Body.Variables[1];
+#endif
 
     if (vText.VariableType.FullName != modder.Module.TypeSystem.String.FullName)
         throw new NotSupportedException("Expected the first variable to be string");
+#if TerrariaServer_1450_OrAbove || Terraria__1450_OrAbove || tModLoader_1450_OrAbove
+#else
     if (vTextLowered.VariableType.FullName != modder.Module.TypeSystem.String.FullName)
         throw new NotSupportedException("Expected the second variable to be string");
-
+#endif
     var exceptionHandler = startDedInputCallBack.Body.ExceptionHandlers.Single(
         x => (
             x.TryStart.Next.OpCode == OpCodes.Ldstr
@@ -62,8 +67,12 @@ void HookCommandProcessing(MonoModder modder)
 
     exceptionHandler.TryStart.ReplaceTransfer(newStart, startDedInputCallBack.Method);
 
+#if TerrariaServer_1450_OrAbove || Terraria__1450_OrAbove || tModLoader_1450_OrAbove
+    startDedInputCallBack.EmitDelegate<Func<string, bool>>(OTAPI.Hooks.Main.InvokeCommandProcess);
+#else
     startDedInputCallBack.Emit(OpCodes.Ldloc, vTextLowered)
         .EmitDelegate<Func<string, string, bool>>(OTAPI.Hooks.Main.InvokeCommandProcess);
+#endif
     startDedInputCallBack.Emit(OpCodes.Brfalse, exceptionHandler.TryEnd.Previous);
 }
 
@@ -87,6 +96,17 @@ namespace OTAPI
                 var args = new CommandProcessEventArgs()
                 {
                     Lowered = lowered,
+                    Command = raw,
+                };
+                CommandProcess?.Invoke(null, args);
+                return args.Result != HookResult.Cancel;
+            }
+            
+            public static bool InvokeCommandProcess(string raw)
+            {
+                var args = new CommandProcessEventArgs()
+                {
+                    Lowered = raw.ToLower(),
                     Command = raw,
                 };
                 CommandProcess?.Invoke(null, args);


### PR DESCRIPTION
v1.4.5 uses `EqualsCommand` to compare commands and removes the lowercase command text.

### 1.4.4.9
<img width="581" height="308" alt="8b5a8f62656a0d1bf01e557210c37763" src="https://github.com/user-attachments/assets/b3ffdf05-13ae-497d-85e2-c6c576449a8f" />

### Current
<img width="625" height="336" alt="9a3746e8634056cab1bc05856dbb7934" src="https://github.com/user-attachments/assets/23cc9d9c-b6b7-44f6-88b0-1ff6bfa659a3" />

### This PR
<img width="690" height="320" alt="image" src="https://github.com/user-attachments/assets/7c8473a5-3883-4fd2-9666-d1219e020b45" />
