### PR TITLE
Fix projectile strike source in Damage_PVE_Inner

### DIFF
--- a/OTAPI.Scripts/Patches/PatchNpcStrikeArgs.Server.cs
+++ b/OTAPI.Scripts/Patches/PatchNpcStrikeArgs.Server.cs
@@ -101,11 +101,10 @@ partial class NpcStrikeArgs
 
                             case "Player.ApplyDamageToNPC":
                             case "Player.ItemCheck_MeleeHitNPCs":
+                            case "Projectile.Damage":
                             case "Player.ProcessHitAgainstNPC":
                             case "NPC.StrikeNPC":
-#if TerrariaServer_1450_OrAbove || Terraria__1450_OrAbove || tModLoader_1450_OrAbove
-                            case "Projectile.Damage_PVE_Inner": // introduced/split in 145+
-#endif
+                            case "Projectile.Damage_PVE_Inner":
                                 body.GetILProcessor().InsertBefore(instr,
                                     new { OpCodes.Ldarg_0 }
                                 );

--- a/OTAPI.Scripts/Patches/PatchNpcStrikeArgs.Server.cs
+++ b/OTAPI.Scripts/Patches/PatchNpcStrikeArgs.Server.cs
@@ -101,10 +101,11 @@ partial class NpcStrikeArgs
 
                             case "Player.ApplyDamageToNPC":
                             case "Player.ItemCheck_MeleeHitNPCs":
-                            case "Projectile.Damage":
                             case "Player.ProcessHitAgainstNPC":
                             case "NPC.StrikeNPC":
-                            case "Projectile.Damage_PVE_Inner":
+#if TerrariaServer_1450_OrAbove || Terraria__1450_OrAbove || tModLoader_1450_OrAbove
+                            case "Projectile.Damage_PVE_Inner": // introduced/split in 145+
+#endif
                                 body.GetILProcessor().InsertBefore(instr,
                                     new { OpCodes.Ldarg_0 }
                                 );

--- a/OTAPI.Scripts/Patches/PatchNpcStrikeArgs.Server.cs
+++ b/OTAPI.Scripts/Patches/PatchNpcStrikeArgs.Server.cs
@@ -104,16 +104,9 @@ partial class NpcStrikeArgs
                             case "Projectile.Damage":
                             case "Player.ProcessHitAgainstNPC":
                             case "NPC.StrikeNPC":
+                            case "Projectile.Damage_PVE_Inner":
                                 body.GetILProcessor().InsertBefore(instr,
                                     new { OpCodes.Ldarg_0 }
-                                );
-                                break;
-
-                            case "Projectile.Damage_PVE_Inner":
-                                // find the NPC parameter
-                                var prm = body.Method.Parameters.Single(x => x.ParameterType.FullName == "Terraria.NPC");
-                                body.GetILProcessor().InsertBefore(instr,
-                                    new { OpCodes.Ldarg, Operand = prm }
                                 );
                                 break;
 


### PR DESCRIPTION
Align `Projectile.Damage_PVE_Inner` with `Projectile.Damage` by using ldarg_0 (the projectile instance) as the NPC strike source.