### PR TITLE
Patch AI_067_FreakingPirates_HitIntention to add owner check

### DIFF
--- a/OTAPI.Scripts/Patches/Terraria.Projectile.Both.cs
+++ b/OTAPI.Scripts/Patches/Terraria.Projectile.Both.cs
@@ -1,0 +1,39 @@
+﻿/*
+Copyright (C) 2020 DeathCradle
+
+This file is part of Open Terraria API v3 (OTAPI)
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+#pragma warning disable CS0108 // Member hides inherited member; missing new keyword
+#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
+
+#if TerrariaServer_1450_OrAbove || Terraria__1450_OrAbove || tModLoader_1450_OrAbove
+using Microsoft.Xna.Framework;
+using Terraria;
+
+namespace Terraria
+{
+    partial class patch_Projectile : Terraria.Projectile
+    {
+        private extern void orig_AI_067_FreakingPirates_HitIntention(Vector2 idealPosition);
+
+        private void AI_067_FreakingPirates_HitIntention(Vector2 idealPosition)
+        {
+            if (this.owner != Main.myPlayer) return;
+            orig_AI_067_FreakingPirates_HitIntention(idealPosition);
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Vanilla Exploit
`AI_067_FreakingPirates_HitIntention` lacks an owner check. This causes the Server and all Clients to execute the PickTile logic.

- Players can force the Server to internally execute `PickTile`, bypassing build permissions. 
- Other clients are also forced to execute the `PickTile` logic and send KillTile packets.

While this PR alleviates the issue, clients can still send erroneous KillTile packets (the owner of projectile should send). This exploit should be reported to Re-Logic.