### PR TITLE
Fix missing path separator between recursive glob

### DIFF
--- a/OTAPI.Server.Launcher/OTAPI.Server.Launcher.csproj
+++ b/OTAPI.Server.Launcher/OTAPI.Server.Launcher.csproj
@@ -51,7 +51,7 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="Exists('../OTAPI.Patcher/bin/$(Configuration)/$(TargetFramework)/tModLoader')">
-		<Content Include="../OTAPI.Patcher/bin/$(Configuration)/$(TargetFramework)/tModLoader/***.*">
+		<Content Include="../OTAPI.Patcher/bin/$(Configuration)/$(TargetFramework)/tModLoader/**/*.*">
 			<Link>tModLoader\%(RecursiveDir)%(Filename)%(Extension)</Link>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</Content>


### PR DESCRIPTION
I noticed the commit https://github.com/SignatureBeef/Open-Terraria-API/commit/68dc2cd9eb5b59e0a5bdfd8fedcb8bdbaaec5646#diff-2f8e47b2753ab76579833e0a77ad71a5bb8cdda49dcfe319809fb5d2f05e590cR54 removed one of the path separators turning `**\*.*` to `***.*`. I'm not sure if the behavior has changed but it's better safe